### PR TITLE
add a new target: zkvm

### DIFF
--- a/builder/builtins.go
+++ b/builder/builtins.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/tinygo-org/tinygo/compileopts"
 	"github.com/tinygo-org/tinygo/goenv"
 )
 
@@ -169,7 +170,7 @@ var aeabiBuiltins = []string{
 // For more information, see: https://compiler-rt.llvm.org/
 var CompilerRT = Library{
 	name: "compiler-rt",
-	cflags: func(target, headerPath string) []string {
+	cflags: func(config *compileopts.Config, headerPath string) []string {
 		return []string{"-Werror", "-Wall", "-std=c11", "-nostdlibinc"}
 	},
 	sourceDir: func() string {

--- a/builder/library.go
+++ b/builder/library.go
@@ -172,6 +172,10 @@ func (l *Library) load(config *compileopts.Config, tmpdir string) (job *compileJ
 	if strings.HasPrefix(target, "riscv32-") {
 		args = append(args, "-march=rv32imac", "-mabi=ilp32", "-fforce-enable-int128")
 	}
+	if strings.Compare(target, "riscv32") == 0 {
+		args = append(args, "-march=rv32im", "-mabi=ilp32")
+	}
+
 	if strings.HasPrefix(target, "riscv64-") {
 		args = append(args, "-march=rv64gc", "-mabi=lp64")
 	}

--- a/builder/library.go
+++ b/builder/library.go
@@ -23,7 +23,7 @@ type Library struct {
 	makeHeaders func(target, includeDir string) error
 
 	// cflags returns the C flags specific to this library
-	cflags func(target, headerPath string) []string
+	cflags func(config *compileopts.Config, headerPath string) []string
 
 	// The source directory.
 	sourceDir func() string
@@ -142,7 +142,7 @@ func (l *Library) load(config *compileopts.Config, tmpdir string) (job *compileJ
 	// Note: -fdebug-prefix-map is necessary to make the output archive
 	// reproducible. Otherwise the temporary directory is stored in the archive
 	// itself, which varies each run.
-	args := append(l.cflags(target, headerPath), "-c", "-Oz", "-g", "-ffunction-sections", "-fdata-sections", "-Wno-macro-redefined", "--target="+target, "-fdebug-prefix-map="+dir+"="+remapDir)
+	args := append(l.cflags(config, headerPath), "-c", "-Oz", "-g", "-ffunction-sections", "-fdata-sections", "-Wno-macro-redefined", "--target="+target, "-fdebug-prefix-map="+dir+"="+remapDir)
 	cpu := config.CPU()
 	if cpu != "" {
 		// X86 has deprecated the -mcpu flag, so we need to use -march instead.
@@ -169,11 +169,13 @@ func (l *Library) load(config *compileopts.Config, tmpdir string) (job *compileJ
 		// double.
 		args = append(args, "-mdouble=64")
 	}
+
 	if strings.HasPrefix(target, "riscv32-") {
-		args = append(args, "-march=rv32imac", "-mabi=ilp32", "-fforce-enable-int128")
-	}
-	if strings.Compare(target, "riscv32") == 0 {
-		args = append(args, "-march=rv32im", "-mabi=ilp32")
+		if config.ArchIsRV32Im() {
+			args = append(args, "-march=rv32im", "-mabi=ilp32")
+		} else {
+			args = append(args, "-march=rv32imac", "-mabi=ilp32", "-fforce-enable-int128")
+		}
 	}
 
 	if strings.HasPrefix(target, "riscv64-") {

--- a/builder/mingw-w64.go
+++ b/builder/mingw-w64.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/tinygo-org/tinygo/compileopts"
 	"github.com/tinygo-org/tinygo/goenv"
 )
 
@@ -27,7 +28,7 @@ var MinGW = Library{
 		return err
 	},
 	sourceDir: func() string { return "" }, // unused
-	cflags: func(target, headerPath string) []string {
+	cflags: func(config *compileopts.Config, headerPath string) []string {
 		// No flags necessary because there are no files to compile.
 		return nil
 	},

--- a/builder/musl.go
+++ b/builder/musl.go
@@ -74,8 +74,8 @@ var Musl = Library{
 
 		return nil
 	},
-	cflags: func(target, headerPath string) []string {
-		arch := compileopts.MuslArchitecture(target)
+	cflags: func(config *compileopts.Config, headerPath string) []string {
+		arch := compileopts.MuslArchitecture(config.Triple())
 		muslDir := filepath.Join(goenv.Get("TINYGOROOT"), "lib/musl")
 		return []string{
 			"-std=c99",            // same as in musl

--- a/builder/picolibc.go
+++ b/builder/picolibc.go
@@ -29,7 +29,7 @@ var Picolibc = Library{
 			"-DTINY_STDIO",
 			"-D_IEEE_LIBM",
 			"-D__OBSOLETE_MATH_FLOAT=1", // use old math code that doesn't expect a FPU
-			"-D__OBSOLETE_MATH_DOUBLE=0",
+			"-D__OBSOLETE_MATH_DOUBLE=1",
 			"-nostdlibinc",
 			"-isystem", newlibDir + "/libc/include",
 			"-I" + newlibDir + "/libc/tinystdio",

--- a/builder/picolibc.go
+++ b/builder/picolibc.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/tinygo-org/tinygo/compileopts"
 	"github.com/tinygo-org/tinygo/goenv"
 )
 
@@ -18,10 +19,9 @@ var Picolibc = Library{
 		}
 		return f.Close()
 	},
-	cflags: func(target, headerPath string) []string {
+	cflags: func(config *compileopts.Config, headerPath string) []string {
 		var obsoleteMathDouble string
-		if target == "riscv32" {
-			// If this option is a 0 for the zkvm, it generates floating-point instructions.
+		if config.ArchIsRV32Im() {
 			obsoleteMathDouble = "-D__OBSOLETE_MATH_DOUBLE=1"
 		} else {
 			obsoleteMathDouble = "-D__OBSOLETE_MATH_DOUBLE=0"

--- a/builder/picolibc.go
+++ b/builder/picolibc.go
@@ -19,6 +19,13 @@ var Picolibc = Library{
 		return f.Close()
 	},
 	cflags: func(target, headerPath string) []string {
+		var obsoleteMathDouble string
+		if target == "riscv32" {
+			// If this option is a 0 for the zkvm, it generates floating-point instructions.
+			obsoleteMathDouble = "-D__OBSOLETE_MATH_DOUBLE=1"
+		} else {
+			obsoleteMathDouble = "-D__OBSOLETE_MATH_DOUBLE=0"
+		}
 		newlibDir := filepath.Join(goenv.Get("TINYGOROOT"), "lib/picolibc/newlib")
 		return []string{
 			"-Werror",
@@ -29,7 +36,7 @@ var Picolibc = Library{
 			"-DTINY_STDIO",
 			"-D_IEEE_LIBM",
 			"-D__OBSOLETE_MATH_FLOAT=1", // use old math code that doesn't expect a FPU
-			"-D__OBSOLETE_MATH_DOUBLE=1",
+			obsoleteMathDouble,
 			"-nostdlibinc",
 			"-isystem", newlibDir + "/libc/include",
 			"-I" + newlibDir + "/libc/tinystdio",
@@ -418,4 +425,6 @@ var picolibcSources = []string{
 	"libm/math/s_sin.c",
 	"libm/math/s_tan.c",
 	"libm/math/s_tanh.c",
+	"libm/math/w_exp2.c",
+	"libm/math/wf_exp2.c",
 }

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -341,6 +341,17 @@ func (c *Config) CFlags() []string {
 	return cflags
 }
 
+// RISC-V's target is determined by the -march cflag within the config.
+// This is different from architectures that can rely on the "llvm-target" field.
+func (c *Config) ArchIsRV32Im() bool {
+	for _, s := range c.CFlags() {
+		if s == ("-march=rv32im") {
+			return true
+		}
+	}
+	return false
+}
+
 // LDFlags returns the flags to pass to the linker. A few more flags are needed
 // (like the one for the compiler runtime), but this represents the majority of
 // the flags.

--- a/src/internal/task/task_stack_arm.go
+++ b/src/internal/task/task_stack_arm.go
@@ -1,5 +1,5 @@
-//go:build scheduler.tasks && arm && !cortexm && !avr && !xtensa && !tinygo.riscv
-// +build scheduler.tasks,arm,!cortexm,!avr,!xtensa,!tinygo.riscv
+//go:build scheduler.tasks && arm && !cortexm && !avr && !xtensa && !tinygo.riscv && !tinygo.zkvm
+// +build scheduler.tasks,arm,!cortexm,!avr,!xtensa,!tinygo.riscv,!tinygo.zkvm
 
 package task
 

--- a/src/internal/task/task_stack_tinygoriscv.go
+++ b/src/internal/task/task_stack_tinygoriscv.go
@@ -1,5 +1,6 @@
-//go:build scheduler.tasks && tinygo.riscv
-// +build scheduler.tasks,tinygo.riscv
+//go:build scheduler.tasks && (tinygo.riscv || tinygo.zkvm)
+// +build scheduler.tasks
+// +build tinygo.riscv tinygo.zkvm
 
 package task
 

--- a/src/runtime/baremetal.go
+++ b/src/runtime/baremetal.go
@@ -1,5 +1,5 @@
-//go:build baremetal
-// +build baremetal
+//go:build baremetal && !tinygo.zkvm
+// +build baremetal,!tinygo.zkvm
 
 package runtime
 

--- a/src/runtime/interrupt/interrupt_none.go
+++ b/src/runtime/interrupt/interrupt_none.go
@@ -1,5 +1,5 @@
-//go:build !baremetal
-// +build !baremetal
+//go:build !baremetal || tinygo.zkvm
+// +build !baremetal tinygo.zkvm
 
 package interrupt
 

--- a/src/runtime/runtime_unix.go
+++ b/src/runtime/runtime_unix.go
@@ -1,6 +1,7 @@
-//go:build (darwin || (linux && !baremetal && !wasi)) && !nintendoswitch
+//go:build (darwin || (linux && !baremetal && !wasi)) && !nintendoswitch && !tinygo.zkvm
 // +build darwin linux,!baremetal,!wasi
 // +build !nintendoswitch
+// +build !tinygo.zkvm
 
 package runtime
 

--- a/src/runtime/runtime_zkvm.go
+++ b/src/runtime/runtime_zkvm.go
@@ -1,0 +1,67 @@
+//go:build tinygo.zkvm
+// +build tinygo.zkvm
+
+package runtime
+
+import (
+	"device/riscv"
+)
+
+type timeUnit int64
+
+var timestamp timeUnit
+
+const GOARCH = "zkvm"
+const TargetBits = 32
+
+//export main
+func main() {
+	run()
+	exit(0)
+}
+
+// Align on word boundary.
+func align(ptr uintptr) uintptr {
+	return (ptr + 3) &^ 3
+}
+
+func ticksToNanoseconds(ticks timeUnit) int64 {
+	return int64(ticks)
+}
+
+func nanosecondsToTicks(ns int64) timeUnit {
+	return timeUnit(ns)
+}
+
+func sleepTicks(d timeUnit) {
+	// TODO
+	timestamp += d
+}
+
+func ticks() timeUnit {
+	return timestamp
+}
+
+func putchar(c byte) {
+	// TODO
+	return
+}
+
+func getchar() byte {
+	// TODO
+	return 0
+}
+
+func buffered() int {
+	// TODO
+	return 0
+}
+
+func abort() {
+	exit(1)
+}
+
+func exit(code int) {
+	riscv.Asm("li t0, 0")
+	riscv.Asm("ecall")
+}

--- a/src/runtime/runtime_zkvm.go
+++ b/src/runtime/runtime_zkvm.go
@@ -5,6 +5,7 @@ package runtime
 
 import (
 	"device/riscv"
+	"unsafe"
 )
 
 type timeUnit int64
@@ -16,8 +17,24 @@ const TargetBits = 32
 
 //export main
 func main() {
+	preinit()
 	run()
 	exit(0)
+}
+
+//go:extern __bss_begin
+var __bss_begin [0]byte
+
+//go:extern __bss_end
+var __bss_end [0]byte
+
+func preinit() {
+	// Initialize .bss: zero-initialized global variables.
+	ptr := unsafe.Pointer(&__bss_begin)
+	for ptr != unsafe.Pointer(&__bss_end) {
+		*(*uint32)(ptr) = 0
+		ptr = unsafe.Pointer(uintptr(ptr) + 4)
+	}
 }
 
 // Align on word boundary.

--- a/src/runtime/runtime_zkvm.go
+++ b/src/runtime/runtime_zkvm.go
@@ -60,7 +60,15 @@ func ticks() timeUnit {
 }
 
 func putchar(c byte) {
-	// TODO
+	// Do the move first because the parameter c is stored in a0, which gets overwritten for the syscall
+	riscv.AsmFull("mv a1, {value}",
+		map[string]interface{}{"value": uintptr(unsafe.Pointer(&c))})
+	riscv.Asm("li t0, 2") // software ecall
+	riscv.Asm("li a7, 2") // SYS_IO
+	riscv.Asm("li a0, 1") // stdout
+	// We're only printing a single character. Set the buffer length = 1
+	riscv.Asm("li a2, 1")
+	riscv.Asm("ecall")
 	return
 }
 

--- a/src/runtime/runtime_zkvm.go
+++ b/src/runtime/runtime_zkvm.go
@@ -8,12 +8,54 @@ import (
 	"unsafe"
 )
 
-type timeUnit int64
+const GOARCH = "zkvm"
+
+// The bitness of the CPU (e.g. 8, 32, 64).
+const TargetBits = 32
+
+const deferExtraRegs = 0
+
+type timeUnit uint32
 
 var timestamp timeUnit
 
-const GOARCH = "zkvm"
-const TargetBits = 32
+const baremetal = false
+
+//go:extern _heap_start
+var heapStartSymbol [0]byte
+
+//go:extern _heap_end
+var heapEndSymbol [0]byte
+
+//go:extern _globals_start
+var globalsStartSymbol [0]byte
+
+//go:extern _globals_end
+var globalsEndSymbol [0]byte
+
+//go:extern _stack_top
+var stackTopSymbol [0]byte
+
+var (
+	heapStart    = uintptr(unsafe.Pointer(&heapStartSymbol))
+	heapEnd      = uintptr(unsafe.Pointer(&heapEndSymbol))
+	globalsStart = uintptr(unsafe.Pointer(&globalsStartSymbol))
+	globalsEnd   = uintptr(unsafe.Pointer(&globalsEndSymbol))
+	stackTop     = uintptr(unsafe.Pointer(&stackTopSymbol))
+)
+
+func growHeap() bool {
+	// On zkvm, there is no way the heap can be grown.
+	return false
+}
+
+//go:linkname procPin sync/atomic.runtime_procPin
+func procPin() {
+}
+
+//go:linkname procUnpin sync/atomic.runtime_procUnpin
+func procUnpin() {
+}
 
 //export main
 func main() {
@@ -37,11 +79,6 @@ func preinit() {
 	}
 }
 
-// Align on word boundary.
-func align(ptr uintptr) uintptr {
-	return (ptr + 3) &^ 3
-}
-
 func ticksToNanoseconds(ticks timeUnit) int64 {
 	return int64(ticks)
 }
@@ -55,10 +92,6 @@ func sleepTicks(d timeUnit) {
 	timestamp += d
 }
 
-func ticks() timeUnit {
-	return timestamp
-}
-
 func putchar(c byte) {
 	// Do the move first because the parameter c is stored in a0, which gets overwritten for the syscall
 	riscv.AsmFull("mv a1, {value}",
@@ -66,27 +99,47 @@ func putchar(c byte) {
 	riscv.Asm("li t0, 2") // software ecall
 	riscv.Asm("li a7, 2") // SYS_IO
 	riscv.Asm("li a0, 1") // stdout
-	// We're only printing a single character. Set the buffer length = 1
+	// we're only printing a single character. Set the buffer length = 1
 	riscv.Asm("li a2, 1")
 	riscv.Asm("ecall")
 	return
-}
-
-func getchar() byte {
-	// TODO
-	return 0
-}
-
-func buffered() int {
-	// TODO
-	return 0
 }
 
 func abort() {
 	exit(1)
 }
 
+//go:linkname exit syscall.Exit
 func exit(code int) {
 	riscv.Asm("li t0, 0")
 	riscv.Asm("ecall")
+}
+
+//go:linkname now time.now
+func now() (sec int64, nsec int32, mono int64) {
+	mono = nanotime()
+	sec = mono / (1000 * 1000 * 1000)
+	nsec = int32((mono) - sec*(1000*1000*1000))
+	return
+}
+
+// zkVM has no notion of time the closest thing to time is the current cycle count
+func ticks() timeUnit {
+	var cycle_count uint32
+	riscv.Asm("li t0, 2") // software ecall
+	riscv.Asm("li a7, 4") // SYS_CYCLE_COUNT
+	riscv.Asm("ecall")
+	riscv.AsmFull("mv {value}, a0",
+		map[string]interface{}{"value": cycle_count})
+
+	return timeUnit(cycle_count)
+}
+
+// Align on word boundary.
+func align(ptr uintptr) uintptr {
+	return (ptr + 3) &^ 3
+}
+
+func getCurrentStackPointer() uintptr {
+	return uintptr(stacksave())
 }

--- a/targets/riscv32im-risc0-zkvm-elf.ld
+++ b/targets/riscv32im-risc0-zkvm-elf.ld
@@ -1,0 +1,82 @@
+/*
+  Copyright 2022 Risc0, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+OUTPUT_FORMAT("elf32-littleriscv", "elf32-littleriscv", "elf32-littleriscv")
+OUTPUT_ARCH(riscv)
+ENTRY(_start)
+EXTERN(__start)
+
+/* Must match risc0/zkvm/platform/src/memory.rs */
+MEMORY {
+  stack        : ORIGIN = 0x00000000, LENGTH =  16M
+  data    (RW) : ORIGIN = 0x01000000, LENGTH =  16M
+  heap         : ORIGIN = 0x02000000, LENGTH =  32M
+  input        : ORIGIN = 0x04000000, LENGTH =  32M
+  prog    (X)  : ORIGIN = 0x06000000, LENGTH =  32M
+}
+
+SECTIONS {
+  .text : {
+    *(.text._start)
+    *(.text.__start)
+    *(.text*)
+    *(.rodata*)
+    *(.srodata*)
+  } >prog
+
+  .data : {
+    *(.data .data.*)
+    *(.gnu.linkonce.d.*)
+    __global_pointer$ = . + 0x800;
+    *(.sdata .sdata.* .sdata2.*)
+    *(.gnu.linkonce.s.*)
+  } >data
+
+  . = ALIGN(4);
+
+  .bss (NOLOAD) :  {
+    __bss_begin = .;
+    *(.sbss*)
+    *(.gnu.linkonce.sb.*)
+    *(.bss .bss.*)
+    *(.gnu.linkonce.b.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __result = .;
+    /* Result is 9 words * 4 = 36 bytes, 8 words for output, and 1 word for output size*/
+    __bss_end = . + 36;
+  } >data
+
+  __bss_size = __bss_end - __bss_begin;
+
+  __heap_start = ORIGIN(heap);
+  __heap_end = __heap_start + LENGTH(heap);
+  __heap_size = LENGTH(heap);
+
+  __stack_init$ = ORIGIN(stack) + LENGTH(stack) - 4;
+
+  /* for tinygo's mm */
+  _heap_start = __heap_start;
+  _heap_end = __heap_end;
+  _stack_top = __stack_init$;
+
+  /DISCARD/ : {
+    *(.rel*)
+    *(.comment)
+    *(.eh_frame)
+    *(.riscv.attributes)
+  }
+}

--- a/targets/riscv32im-risc0-zkvm-elf.ld
+++ b/targets/riscv32im-risc0-zkvm-elf.ld
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 Risc0, Inc.
+  Copyright 2023 Risc0, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -17,25 +17,28 @@
 OUTPUT_FORMAT("elf32-littleriscv", "elf32-littleriscv", "elf32-littleriscv")
 OUTPUT_ARCH(riscv)
 ENTRY(_start)
-EXTERN(__start)
 
 /* Must match risc0/zkvm/platform/src/memory.rs */
 MEMORY {
-  stack        : ORIGIN = 0x00000000, LENGTH =  16M
-  data    (RW) : ORIGIN = 0x01000000, LENGTH =  16M
-  heap         : ORIGIN = 0x02000000, LENGTH =  32M
-  input        : ORIGIN = 0x04000000, LENGTH =  32M
+  stack        : ORIGIN = 0x02000000, LENGTH =  16M
+  data    (RW) : ORIGIN = 0x03000000, LENGTH =  16M
+  heap         : ORIGIN = 0x04000000, LENGTH =  32M
   prog    (X)  : ORIGIN = 0x06000000, LENGTH =  32M
 }
 
 SECTIONS {
+
   .text : {
-    *(.text._start)
-    *(.text.__start)
+    KEEP (*(.init))
+    . = ALIGN(4);
     *(.text*)
+    . = ALIGN(4);
     *(.rodata*)
+    . = ALIGN(4);
     *(.srodata*)
   } >prog
+
+  . = ALIGN(4);
 
   .data : {
     *(.data .data.*)
@@ -47,7 +50,7 @@ SECTIONS {
 
   . = ALIGN(4);
 
-  .bss (NOLOAD) :  {
+  .bss (NOLOAD) : {
     __bss_begin = .;
     *(.sbss*)
     *(.gnu.linkonce.sb.*)
@@ -55,9 +58,7 @@ SECTIONS {
     *(.gnu.linkonce.b.*)
     *(COMMON)
     . = ALIGN(4);
-    __result = .;
-    /* Result is 9 words * 4 = 36 bytes, 8 words for output, and 1 word for output size*/
-    __bss_end = . + 36;
+    __bss_end = .;
   } >data
 
   __bss_size = __bss_end - __bss_begin;

--- a/targets/zkvm.json
+++ b/targets/zkvm.json
@@ -1,0 +1,17 @@
+{
+    "inherits": ["riscv"],
+	"llvm-target": "riscv32",
+    "scheduler": "none",
+	"build-tags": ["tinygo.zkvm"],
+    "cflags": [
+        "-march=rv32im",
+        "-mabi=ilp32"
+    ],
+    "ldflags": [
+        "-melf32lriscv"
+    ],
+    "gc": "leaking",
+    "features": "+m",
+    "linkerscript": "targets/riscv32im-risc0-zkvm-elf.ld",
+	"gdb": ["gdb-multiarch"]
+}

--- a/targets/zkvm.json
+++ b/targets/zkvm.json
@@ -1,32 +1,32 @@
 {
-    "goos": "linux",
-    "goarch": "arm",
-    "linker": "ld.lld",
-    "rtlib": "compiler-rt",
-    "libc": "picolibc",
-    "llvm-target": "riscv32",
-    "gc": "leaking",
-    "scheduler": "tasks",
-    "default-stack-size": 4096,
-    "build-tags": ["tinygo.zkvm", "baremetal"],
-    "cflags": [
-        "-Werror",
-        "-mno-relax",
-        "-fno-exceptions", "-fno-unwind-tables", "-fno-asynchronous-unwind-tables",
-        "-ffunction-sections", "-fdata-sections",
-        "-march=rv32im",
-        "-mabi=ilp32"
-    ],
-    "ldflags": [
-        "-melf32lriscv", "--gc-sections"
-    ],
-    "features": "+m",
-    "linkerscript": "targets/riscv32im-risc0-zkvm-elf.ld",
-    "emulator": "r0vm --elf {}",
-    "gdb": ["riscv64-unknown-elf-gdb"],
-    "extra-files": [
-        "src/device/riscv/start.S",
-        "src/runtime/asm_riscv.S",
-        "src/internal/task/task_stack_tinygoriscv.S"
-    ]
+	"goos": "linux",
+	"goarch": "arm",
+	"linker": "ld.lld",
+	"rtlib": "compiler-rt",
+	"libc": "picolibc",
+	"llvm-target": "riscv32-unknown-none",
+	"gc": "leaking",
+	"scheduler": "tasks",
+	"default-stack-size": 4096,
+	"build-tags": ["tinygo.zkvm", "baremetal"],
+	"cflags": [
+		"-Werror",
+		"-mno-relax",
+		"-fno-exceptions", "-fno-unwind-tables", "-fno-asynchronous-unwind-tables",
+		"-ffunction-sections", "-fdata-sections",
+		"-march=rv32im",
+		"-mabi=ilp32"
+	],
+	"ldflags": [
+		"-melf32lriscv", "--gc-sections"
+	],
+	"features": "+m",
+	"linkerscript": "targets/riscv32im-risc0-zkvm-elf.ld",
+	"emulator": "r0vm --elf {}",
+	"gdb": ["riscv64-unknown-elf-gdb"],
+	"extra-files": [
+		"src/device/riscv/start.S",
+		"src/runtime/asm_riscv.S",
+		"src/internal/task/task_stack_tinygoriscv.S"
+	]
 }

--- a/targets/zkvm.json
+++ b/targets/zkvm.json
@@ -6,7 +6,8 @@
     "libc": "picolibc",
     "llvm-target": "riscv32",
     "gc": "leaking",
-    "scheduler": "none",
+    "scheduler": "tasks",
+    "default-stack-size": 1024,
     "build-tags": ["tinygo.zkvm", "baremetal"],
     "cflags": [
         "-Werror",
@@ -25,6 +26,7 @@
     "gdb": ["riscv64-unknown-elf-gdb"],
     "extra-files": [
         "src/device/riscv/start.S",
-        "src/runtime/asm_riscv.S"
+        "src/runtime/asm_riscv.S",
+        "src/internal/task/task_stack_tinygoriscv.S"
     ]
 }

--- a/targets/zkvm.json
+++ b/targets/zkvm.json
@@ -13,5 +13,6 @@
     "gc": "leaking",
     "features": "+m",
     "linkerscript": "targets/riscv32im-risc0-zkvm-elf.ld",
-	"gdb": ["gdb-multiarch"]
+    "gdb": ["gdb-multiarch"],
+    "emulator": "r0vm --elf {}"
 }

--- a/targets/zkvm.json
+++ b/targets/zkvm.json
@@ -7,7 +7,7 @@
     "llvm-target": "riscv32",
     "gc": "leaking",
     "scheduler": "tasks",
-    "default-stack-size": 1024,
+    "default-stack-size": 4096,
     "build-tags": ["tinygo.zkvm", "baremetal"],
     "cflags": [
         "-Werror",

--- a/targets/zkvm.json
+++ b/targets/zkvm.json
@@ -1,18 +1,30 @@
 {
-    "inherits": ["riscv"],
-	"llvm-target": "riscv32",
+    "goos": "linux",
+    "goarch": "arm",
+    "linker": "ld.lld",
+    "rtlib": "compiler-rt",
+    "libc": "picolibc",
+    "llvm-target": "riscv32",
+    "gc": "leaking",
     "scheduler": "none",
-	"build-tags": ["tinygo.zkvm"],
+    "build-tags": ["tinygo.zkvm", "baremetal"],
     "cflags": [
+        "-Werror",
+        "-mno-relax",
+        "-fno-exceptions", "-fno-unwind-tables", "-fno-asynchronous-unwind-tables",
+        "-ffunction-sections", "-fdata-sections",
         "-march=rv32im",
         "-mabi=ilp32"
     ],
     "ldflags": [
-        "-melf32lriscv"
+        "-melf32lriscv", "--gc-sections"
     ],
-    "gc": "leaking",
     "features": "+m",
     "linkerscript": "targets/riscv32im-risc0-zkvm-elf.ld",
-    "gdb": ["gdb-multiarch"],
-    "emulator": "r0vm --elf {}"
+    "emulator": "r0vm --elf {}",
+    "gdb": ["riscv64-unknown-elf-gdb"],
+    "extra-files": [
+        "src/device/riscv/start.S",
+        "src/runtime/asm_riscv.S"
+    ]
 }


### PR DESCRIPTION
This is a first attempt to add the zkvm as a new target. At this point, all files in testdata compile except for those involving goroutines and channels. Some tests can run on r0vm but most fail. The failures require further investigation and it's possible that this code being added contains mistakes...